### PR TITLE
Add PaymentRequest API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ Add `flutter_inappwebview` as a [dependency in your pubspec.yaml file](https://f
 - [macOS](https://inappwebview.dev/docs/intro/#setup-macos)
 - [Windows](https://inappwebview.dev/docs/intro/#setup-windows)
 - [Web](https://inappwebview.dev/docs/intro/#setup-web)
+### Payment Request API (Android)
+
+Use `enablePaymentRequest()` on `InAppWebViewController` to enable the Payment Request API on supported Android WebView (version 94+).
+It returns `true` if the feature is available and has been enabled.
+
 
 ## Support
 

--- a/flutter_inappwebview/example/integration_test/in_app_webview/main.dart
+++ b/flutter_inappwebview/example/integration_test/in_app_webview/main.dart
@@ -185,6 +185,7 @@ part 'webview_windows.dart';
 
 part 'keep_alive.dart';
 
+part 'payment_request.dart';
 void main() {
   final shouldSkip = kIsWeb
       ? false
@@ -284,6 +285,7 @@ void main() {
     handlesURLScheme();
     webViewAssetLoader();
     onContentSizeChanged();
+    paymentRequest();
     keepAlive();
   }, skip: shouldSkip);
 }

--- a/flutter_inappwebview/example/integration_test/in_app_webview/payment_request.dart
+++ b/flutter_inappwebview/example/integration_test/in_app_webview/payment_request.dart
@@ -1,0 +1,28 @@
+part of 'main.dart';
+
+void paymentRequest() {
+  final shouldSkip = kIsWeb
+      ? true
+      : ![TargetPlatform.android].contains(defaultTargetPlatform);
+
+  skippableTestWidgets('enablePaymentRequest', (WidgetTester tester) async {
+    final completer = Completer<InAppWebViewController>();
+    bool? result;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: InAppWebView(
+          key: GlobalKey(),
+          onWebViewCreated: (controller) async {
+            completer.complete(controller);
+            result = await controller.enablePaymentRequest();
+          },
+        ),
+      ),
+    );
+
+    await completer.future;
+    expect(result, isTrue);
+  }, skip: shouldSkip);
+}

--- a/flutter_inappwebview/example/lib/in_app_webiew_example.screen.dart
+++ b/flutter_inappwebview/example/lib/in_app_webiew_example.screen.dart
@@ -220,6 +220,15 @@ class _InAppWebViewExampleScreenState extends State<InAppWebViewExampleScreen> {
                   webViewController?.reload();
                 },
               ),
+              ElevatedButton(
+                child: Text("Enable PaymentRequest"),
+                onPressed: () async {
+                  final enabled = await webViewController?.enablePaymentRequest() ?? false;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text("PaymentRequest enabled: $enabled")),
+                  );
+                },
+              ),
             ],
           ),
         ])));

--- a/flutter_inappwebview/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/flutter_inappwebview/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -243,6 +243,10 @@ class InAppWebViewController {
   ///{@macro flutter_inappwebview_platform_interface.PlatformInAppWebViewController.resumeTimers}
   Future<void> resumeTimers() => platform.resumeTimers();
 
+  ///{@macro flutter_inappwebview_platform_interface.PlatformInAppWebViewController.enablePaymentRequest}
+  Future<bool> enablePaymentRequest({bool retain = true}) =>
+      platform.enablePaymentRequest(retain: retain);
+
   ///{@macro flutter_inappwebview_platform_interface.PlatformInAppWebViewController.printCurrentPage}
   Future<PrintJobController?> printCurrentPage(
       {PrintJobSettings? settings}) async {

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/InAppWebViewInterface.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/InAppWebViewInterface.java
@@ -122,4 +122,6 @@ public interface InAppWebViewInterface {
   @Nullable
   byte[] saveState();
   boolean restoreState(byte[] state);
+
+  boolean enablePaymentRequest(boolean retain);
 }

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/WebViewChannelDelegate.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/WebViewChannelDelegate.java
@@ -727,6 +727,15 @@ public class WebViewChannelDelegate extends ChannelDelegateImpl {
           result.success(false);
         }
         break;
+      case enablePaymentRequest:
+        if (webView != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+          Boolean retain = (Boolean) call.argument("retain");
+          boolean value = webView.enablePaymentRequest(retain != null ? retain : true);
+          result.success(value);
+        } else {
+          result.success(false);
+        }
+        break;
     }
   }
 

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/WebViewChannelDelegateMethods.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/WebViewChannelDelegateMethods.java
@@ -88,4 +88,5 @@ public enum WebViewChannelDelegateMethods {
   showInputMethod,
   saveState,
   restoreState,
+  enablePaymentRequest,
 }

--- a/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/InAppWebView.java
+++ b/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/InAppWebView.java
@@ -2170,6 +2170,19 @@ final public class InAppWebView extends InputAwareWebView implements InAppWebVie
     return restored;
   }
 
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  public boolean enablePaymentRequest(boolean retain) {
+    if (!WebViewFeature.isFeatureSupported(WebViewFeature.PAYMENT_REQUEST)) {
+      return false;
+    }
+    WebSettings settings = getSettings();
+    WebSettingsCompat.setPaymentRequestEnabled(settings, true);
+    if (retain) {
+      WebSettingsCompat.setHasEnrolledInstrumentEnabled(settings, true);
+    }
+    return true;
+  }
+
 
   @Override
   public void dispose() {

--- a/flutter_inappwebview_android/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/flutter_inappwebview_android/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -2161,6 +2161,15 @@ class AndroidInAppWebViewController extends PlatformInAppWebViewController
     await channel?.invokeMethod('resumeTimers', args);
   }
 
+  /// Enables the Payment Request API if supported by the current WebView.
+  Future<bool> enablePaymentRequest({bool retain = true}) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('retain', () => retain);
+    args.putIfAbsent('id', () => id);
+    return await channel?.invokeMethod<bool>('enablePaymentRequest', args) ??
+        false;
+  }
+
   @override
   Future<AndroidPrintJobController?> printCurrentPage(
       {PrintJobSettings? settings}) async {

--- a/flutter_inappwebview_platform_interface/lib/src/in_app_webview/platform_inappwebview_controller.dart
+++ b/flutter_inappwebview_platform_interface/lib/src/in_app_webview/platform_inappwebview_controller.dart
@@ -2483,6 +2483,21 @@ abstract class PlatformInAppWebViewController extends PlatformInterface
         'enableSlowWholeDocumentDraw is not implemented on the current platform');
   }
 
+  /// Enables the Payment Request API on Android WebView if supported.
+  ///
+  /// Returns `true` when the feature is available and has been enabled.
+  /// If the current WebView implementation doesn't support it, `false` is
+  /// returned.
+  ///
+  /// The optional [retain] parameter allows retaining the permission for the
+  /// current origin so that the prompt will not be shown again.
+  ///
+  /// **NOTE**: available only on Android Lollipop (API 21)+.
+  Future<bool> enablePaymentRequest({bool retain = true}) {
+    throw UnimplementedError(
+        'enablePaymentRequest is not implemented on the current platform');
+  }
+
   ///{@template flutter_inappwebview_platform_interface.PlatformInAppWebViewController.setJavaScriptBridgeName}
   ///Sets the name of the JavaScript Bridge object that will be used to interact with the WebView.
   ///This method should be called before any WebViews are created or when there are no WebViews.


### PR DESCRIPTION
## Summary
- enable PaymentRequest API in Android WebView
- expose `enablePaymentRequest` on `InAppWebViewController`
- document Payment Request API usage
- test payment request integration
- example app button to enable API

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889f21f5f9c8329bb0475023c4c989c